### PR TITLE
Relax rails dependency to lower than 6.0

### DIFF
--- a/administrate-field-enum.gemspec
+++ b/administrate-field-enum.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |s|
   s.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
 
   s.add_dependency 'administrate'
-  s.add_dependency 'rails', '>= 4.2', '< 5.2'
+  s.add_dependency 'rails', '>= 4.2', '< 6.0'
 end


### PR DESCRIPTION
This gem worked with rails 5.2.0.beta2, so it should work with final.